### PR TITLE
Deploy flask app

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "rabshab/iati-partner-search-app",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "5000"
+    }
+  ]
+}

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.7
+
+COPY /app /iati-partner-search/app
+COPY /python /iati-partner-search/python
+COPY /data /iati-partner-search/data
+COPY /input /iati-partner-search/input
+COPY requirements.txt /iati-partner-search
+
+WORKDIR /iati-partner-search
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    pip install ipython black flake8
+
+# download the data we need from NLTK
+RUN python -c "import nltk; nltk.download('stopwords'); nltk.download('words')"
+
+ENV FLASK_APP app/main.py 
+
+EXPOSE 5000
+
+CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]

--- a/readme.md
+++ b/readme.md
@@ -65,3 +65,20 @@ python -m flask run --host=0.0.0.0
 ```
 
 After a few seconds of start up time it should be up and running. Navigate to `localhost:5000` in your web browser to view the page.
+
+There is also the docker container which is used for running the application in production which is described by `app.Dockerfile`. To use this one instead it is necessary to remove `data/` from the `.dockerignore` first. 
+
+Then run 
+
+```bash 
+docker build -t iati-partner-search-app -f .\app.Dockerfile .
+```
+
+to build the image and
+
+```bash
+docker run --name=ipsapp -p 5000:5000 iati-partner-search-app
+```
+to run it.
+
+After a few seconds of start up time it should be up and running. Navigate to `localhost:5000` in your web browser to view the page.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy
 pandas
 matplotlib
 Flask
+fuzzywuzzy


### PR DESCRIPTION
Fixes #39 

A dockerfile was added that has creates an image with a more explicit remit of running the application. Most notably it loads the `/data` directory into the image. There is a gotcha at the moment as this isn't compatible with the current `.dockerignore` which includes `data/`. I just removed this when developing locally and pushing the docker image up in lieu of thinking of a smarter solution. I've added some info to the readme about this.

The `Dockerrun.aws.json` is a trivial config file needed for elastic beanstalk which tells it where to find the docker image and what port to expose. 
