### PR TITLE
Fix python imports when running python code as scripts

### DIFF
--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -28,6 +28,6 @@ jobs:
           python ips_python/cosine.py
           python ips_python/refinement.py
           python ips_python/script.py
+          python ips_python/word2vecmodel.py
           python ips_python/word2vecaverage.py
           python ips_python/word2veccosine.py
-          python ips_python/word2vecmodel.py

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -11,13 +11,15 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-
-      - name: Check Scripts Run
+      - name: Install and Set Up Data
         run: |
           pip install invoke
           invoke install-all --quiet
           invoke download-nltk-data
           cp ips_python/tests/test_data/sample_test_data.csv data/all_downloaded_records.csv
+
+      - name: Check Scripts Run
+        run: |
           # these are all of the scripts that have been refactored to fit in with the
           # modularized structure.
           # we simply want to be sure that these script's __main__ functions work without error

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install and Set Up Data
         run: |
           pip install invoke
-          invoke install-all --quiet
+          invoke install-all
           invoke download-nltk-data
           cp ips_python/tests/test_data/sample_test_data.csv data/all_downloaded_records.csv
 

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check Scripts Run
         run: |
           pip install invoke
-          invoke install-all
+          invoke install-all --quiet
           invoke download-nltk-data
           cp ips_python/tests/test_data/sample_test_data.csv data/all_downloaded_records.csv
           # these are all of the scripts that have been refactored to fit in with the

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -25,7 +25,7 @@ jobs:
           python ips_python/vectorize.py
           python ips_python/cosine.py
           python ips_python/refinement.py
-          python ips_python/scripts.py
+          python ips_python/script.py
           python ips_python/word2vecaverage.py
           python ips_python/word2veccosine.py
           python ips_python/word2vecmodel.py

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -23,6 +23,7 @@ jobs:
           # we simply want to be sure that these script's __main__ functions work without error
           python ips_python/preprocessing.py
           python ips_python/vectorize.py
+          python ips_python/cosine.py
           python ips_python/refinement.py
           python ips_python/scripts.py
           python ips_python/word2vecaverage.py

--- a/.github/workflows/checkscriptsrun.yml
+++ b/.github/workflows/checkscriptsrun.yml
@@ -1,0 +1,30 @@
+name: Check python scripts run
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Check Scripts Run
+        run: |
+          pip install invoke
+          invoke install-all
+          invoke download-nltk-data
+          cp ips_python/tests/test_data/sample_test_data.csv data/all_downloaded_records.csv
+          # these are all of the scripts that have been refactored to fit in with the
+          # modularized structure.
+          # we simply want to be sure that these script's __main__ functions work without error
+          python ips_python/preprocessing.py
+          python ips_python/vectorize.py
+          python ips_python/refinement.py
+          python ips_python/scripts.py
+          python ips_python/word2vecaverage.py
+          python ips_python/word2veccosine.py
+          python ips_python/word2vecmodel.py

--- a/ips_python/cluster.py
+++ b/ips_python/cluster.py
@@ -5,15 +5,27 @@ import time
 from os.path import join
 import pickle
 from sklearn.cluster import KMeans
-from constants import (
-    PROCESSED_RECORDS_FILENAME,
-    TERM_DOCUMENT_MATRIX_FILENAME,
-    CLUSTERING_SUM_OF_SQUARE_COMPARISON_FILENAME,
-    CLUSTER_CENTROIDS_FILENAME_CONVENTION,
-    ACTIVITY_CLUSTER_ASSIGNMENT_FILENAME_CONVENTION,
-)
-from utils import get_data_path
 from sklearn.decomposition import TruncatedSVD
+
+
+try:
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        CLUSTERING_SUM_OF_SQUARE_COMPARISON_FILENAME,
+        CLUSTER_CENTROIDS_FILENAME_CONVENTION,
+        ACTIVITY_CLUSTER_ASSIGNMENT_FILENAME_CONVENTION,
+    )
+    from ips_python.utils import get_data_path
+except ModuleNotFoundError:
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        CLUSTERING_SUM_OF_SQUARE_COMPARISON_FILENAME,
+        CLUSTER_CENTROIDS_FILENAME_CONVENTION,
+        ACTIVITY_CLUSTER_ASSIGNMENT_FILENAME_CONVENTION,
+    )
+    from utils import get_data_path
 
 
 def plot_kmean_results(result_dict):

--- a/ips_python/cosine.py
+++ b/ips_python/cosine.py
@@ -3,10 +3,10 @@ import pickle
 import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 
-from ips_python.utils import get_data_path
 from os.path import join
 
 try:
+    from ips_python.utils import get_data_path
     from ips_python.preprocessing import preprocess_query_text
     from ips_python.vectorize import vectorize_input_text
     from ips_python.constants import (
@@ -16,6 +16,7 @@ try:
         COSINE_FILENAME,
     )
 except ModuleNotFoundError:
+    from utils import get_data_path
     from preprocessing import preprocess_query_text
     from vectorize import vectorize_input_text
     from constants import (

--- a/ips_python/cosine.py
+++ b/ips_python/cosine.py
@@ -6,14 +6,24 @@ from sklearn.metrics.pairwise import cosine_similarity
 from ips_python.utils import get_data_path
 from os.path import join
 
-from ips_python.preprocessing import preprocess_query_text
-from ips_python.vectorize import vectorize_input_text
-from ips_python.constants import (
-    PROCESSED_RECORDS_FILENAME,
-    TERM_DOCUMENT_MATRIX_FILENAME,
-    VECTORIZER_FILENAME,
-    COSINE_FILENAME,
-)
+try:
+    from ips_python.preprocessing import preprocess_query_text
+    from ips_python.vectorize import vectorize_input_text
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+        COSINE_FILENAME,
+    )
+except ModuleNotFoundError:
+    from preprocessing import preprocess_query_text
+    from vectorize import vectorize_input_text
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+        COSINE_FILENAME,
+    )
 
 
 def get_cosine_similarity(

--- a/ips_python/embeddingsoverIATI.py
+++ b/ips_python/embeddingsoverIATI.py
@@ -3,18 +3,30 @@ import pandas as pd
 from os.path import join
 from sklearn.metrics.pairwise import cosine_similarity
 import pickle
-from utils import get_data_path
-from preprocessing import preprocess_query_text
 import time
 from gensim.models import Word2Vec
 import operator
-from constants import (
-    PROCESSED_RECORDS_FILENAME,
-    TERM_DOCUMENT_MATRIX_FILENAME,
-    VECTORIZER_FILENAME,
-    MODEL_NAME,
-    WORD_LIST_FILENAME,
-)
+
+try:
+    from ips_python.utils import get_data_path
+    from ips_python.preprocessing import preprocess_query_text
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+        MODEL_NAME,
+        WORD_LIST_FILENAME,
+    )
+except ModuleNotFoundError:
+    from utils import get_data_path
+    from preprocessing import preprocess_query_text
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+        MODEL_NAME,
+        WORD_LIST_FILENAME,
+    )
 
 
 # get data ready into lists

--- a/ips_python/preprocessing.py
+++ b/ips_python/preprocessing.py
@@ -7,12 +7,20 @@ from nltk.stem import WordNetLemmatizer
 from langdetect import detect
 import time
 
-from ips_python.utils import get_data_path, get_input_path
-from ips_python.constants import (
-    PROCESSED_RECORDS_FILENAME,
-    INPUT_DATA_FILENAME,
-    STOPWORDS_FILENAME,
-)
+try:
+    from ips_python.utils import get_data_path, get_input_path
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        INPUT_DATA_FILENAME,
+        STOPWORDS_FILENAME,
+    )
+except ModuleNotFoundError:
+    from utils import get_data_path, get_input_path
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        INPUT_DATA_FILENAME,
+        STOPWORDS_FILENAME,
+    )
 
 
 def preprocessing_initial_text_clean(p_df, p_text):

--- a/ips_python/refinement.py
+++ b/ips_python/refinement.py
@@ -3,9 +3,14 @@ from os.path import join
 
 import pandas as pd
 
-from ips_python.utils import get_data_path
-from ips_python.constants import INPUT_DATA_FILENAME, COSINE_FILENAME
-from ips_python.preprocessing import preprocessing_initial_text_clean
+try:
+    from ips_python.utils import get_data_path
+    from ips_python.constants import INPUT_DATA_FILENAME, COSINE_FILENAME
+    from ips_python.preprocessing import preprocessing_initial_text_clean
+except ModuleNotFoundError:
+    from utils import get_data_path
+    from constants import INPUT_DATA_FILENAME, COSINE_FILENAME
+    from preprocessing import preprocessing_initial_text_clean
 
 
 def process_results(initial_result_df, full_iati_records, number_of_results=100):

--- a/ips_python/script.py
+++ b/ips_python/script.py
@@ -1,8 +1,18 @@
-from ips_python.preprocessing import preprocess_query_text
-from ips_python.vectorize import create_tfidf_term_document_matrix, vectorize_input_text
-from ips_python.cosine import get_cosine_similarity
-from ips_python.refinement import process_results, gather_top_results
-from ips_python.word2vecaverage import average_per_doc
+try:
+    from ips_python.preprocessing import preprocess_query_text
+    from ips_python.vectorize import (
+        create_tfidf_term_document_matrix,
+        vectorize_input_text,
+    )
+    from ips_python.cosine import get_cosine_similarity
+    from ips_python.refinement import process_results, gather_top_results
+    from ips_python.word2vecaverage import average_per_doc
+except ModuleNotFoundError:
+    from preprocessing import preprocess_query_text
+    from vectorize import create_tfidf_term_document_matrix, vectorize_input_text
+    from cosine import get_cosine_similarity
+    from refinement import process_results, gather_top_results
+    from word2vecaverage import average_per_doc
 
 
 def download_data():

--- a/ips_python/script.py
+++ b/ips_python/script.py
@@ -1,15 +1,12 @@
 try:
     from ips_python.preprocessing import preprocess_query_text
-    from ips_python.vectorize import (
-        create_tfidf_term_document_matrix,
-        vectorize_input_text,
-    )
+    from ips_python.vectorize import vectorize_input_text
     from ips_python.cosine import get_cosine_similarity
     from ips_python.refinement import process_results, gather_top_results
     from ips_python.word2vecaverage import average_per_doc
 except ModuleNotFoundError:
     from preprocessing import preprocess_query_text
-    from vectorize import create_tfidf_term_document_matrix, vectorize_input_text
+    from vectorize import vectorize_input_text
     from cosine import get_cosine_similarity
     from refinement import process_results, gather_top_results
     from word2vecaverage import average_per_doc
@@ -20,11 +17,6 @@ def download_data():
     this is a placeholder function to show that we need to run something in order to procure the data
     """
     pass
-
-
-def main():
-    download_data()
-    create_tfidf_term_document_matrix()
 
 
 def process_query(
@@ -57,7 +49,3 @@ def process_query_embeddings(
     smart_results = process_results(df_result, full_iati_records)
     top_results = gather_top_results(smart_results, "reporting.org", 3)
     return top_results
-
-
-if __name__ == "__main__":
-    main()

--- a/ips_python/vectorize.py
+++ b/ips_python/vectorize.py
@@ -3,13 +3,22 @@ from os.path import join
 import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 
-from ips_python.utils import get_data_path
-from ips_python.constants import (
-    PROCESSED_RECORDS_FILENAME,
-    WORD_LIST_FILENAME,
-    TERM_DOCUMENT_MATRIX_FILENAME,
-    VECTORIZER_FILENAME,
-)
+try:
+    from ips_python.utils import get_data_path
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        WORD_LIST_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+    )
+except ModuleNotFoundError:
+    from utils import get_data_path
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        WORD_LIST_FILENAME,
+        TERM_DOCUMENT_MATRIX_FILENAME,
+        VECTORIZER_FILENAME,
+    )
 
 
 def create_tfidf_term_document_matrix(preprocessed_text_dataframe):

--- a/ips_python/word2vecaverage.py
+++ b/ips_python/word2vecaverage.py
@@ -1,15 +1,24 @@
-from .utils import get_data_path
 import pandas as pd
 import numpy as np
 from os.path import join
 from gensim.models import Word2Vec
 import pickle
-from .constants import (
-    WORD2VECMODEL_FILENAME,
-    PROCESSED_RECORDS_FILENAME,
-    WORD2VECAVG_FILENAME,
-)
 import time
+
+try:
+    from ips_python.utils import get_data_path
+    from ips_python.constants import (
+        WORD2VECMODEL_FILENAME,
+        PROCESSED_RECORDS_FILENAME,
+        WORD2VECAVG_FILENAME,
+    )
+except ModuleNotFoundError:
+    from utils import get_data_path
+    from constants import (
+        WORD2VECMODEL_FILENAME,
+        PROCESSED_RECORDS_FILENAME,
+        WORD2VECAVG_FILENAME,
+    )
 
 
 def average_per_doc(description_text, w2v_model, dim_size=300):

--- a/ips_python/word2veccosine.py
+++ b/ips_python/word2veccosine.py
@@ -7,12 +7,20 @@ from os.path import join
 from gensim.models import Word2Vec
 import pickle
 
-from constants import (
-    PROCESSED_RECORDS_FILENAME,
-    COSINE_FILENAME,
-    WORD2VECMODEL_FILENAME,
-    WORD2VECAVG_FILENAME,
-)
+try:
+    from ips_python.constants import (
+        PROCESSED_RECORDS_FILENAME,
+        COSINE_FILENAME,
+        WORD2VECMODEL_FILENAME,
+        WORD2VECAVG_FILENAME,
+    )
+except ModuleNotFoundError:
+    from constants import (
+        PROCESSED_RECORDS_FILENAME,
+        COSINE_FILENAME,
+        WORD2VECMODEL_FILENAME,
+        WORD2VECAVG_FILENAME,
+    )
 
 
 if __name__ == "__main__":

--- a/ips_python/word2veccosine.py
+++ b/ips_python/word2veccosine.py
@@ -1,13 +1,13 @@
-from .utils import get_data_path
-from .preprocessing import preprocess_query_text
-from .cosine import get_cosine_similarity
-from .word2vecaverage import average_per_doc
 import pandas as pd
 from os.path import join
 from gensim.models import Word2Vec
 import pickle
 
 try:
+    from ips_python.utils import get_data_path
+    from ips_python.preprocessing import preprocess_query_text
+    from ips_python.cosine import get_cosine_similarity
+    from ips_python.word2vecaverage import average_per_doc
     from ips_python.constants import (
         PROCESSED_RECORDS_FILENAME,
         COSINE_FILENAME,
@@ -15,6 +15,10 @@ try:
         WORD2VECAVG_FILENAME,
     )
 except ModuleNotFoundError:
+    from utils import get_data_path
+    from preprocessing import preprocess_query_text
+    from cosine import get_cosine_similarity
+    from word2vecaverage import average_per_doc
     from constants import (
         PROCESSED_RECORDS_FILENAME,
         COSINE_FILENAME,

--- a/ips_python/word2vecmodel.py
+++ b/ips_python/word2vecmodel.py
@@ -4,7 +4,10 @@ from os.path import join
 from gensim.models import Word2Vec
 import time
 
-from .constants import PROCESSED_RECORDS_FILENAME, WORD2VECMODEL_FILENAME
+try:
+    from ips_python.constants import PROCESSED_RECORDS_FILENAME, WORD2VECMODEL_FILENAME
+except ModuleNotFoundError:
+    from constants import PROCESSED_RECORDS_FILENAME, WORD2VECMODEL_FILENAME
 
 
 def build_w2v_model(input_df, dim_size):

--- a/ips_python/word2vecmodel.py
+++ b/ips_python/word2vecmodel.py
@@ -1,12 +1,13 @@
-from .utils import get_data_path
 import pandas as pd
 from os.path import join
 from gensim.models import Word2Vec
 import time
 
 try:
+    from ips_python.utils import get_data_path
     from ips_python.constants import PROCESSED_RECORDS_FILENAME, WORD2VECMODEL_FILENAME
 except ModuleNotFoundError:
+    from utils import get_data_path
     from constants import PROCESSED_RECORDS_FILENAME, WORD2VECMODEL_FILENAME
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -8,19 +8,29 @@ from ips_python.constants import INPUT_DATA_FILENAME
 
 
 @task
-def install_dependencies(c):
-    c.run("pip install -r requirements.txt")
+def install_dependencies(c, quiet=False):
+    if quiet:
+        c.run("pip install --quiet -r requirements.txt")
+    else:
+        c.run("pip install -r requirements.txt")
 
 
 @task
-def install_dev_dependencies(c):
-    c.run("pip install -r requirements-dev.txt")
+def install_dev_dependencies(c, quiet=False):
+    if quiet:
+        c.run("pip install --quiet -r requirements-dev.txt")
+    else:
+        c.run("pip install -r requirements-dev.txt")
 
 
 @task
-def install_all(c):
-    install_dependencies(c)
-    install_dev_dependencies(c)
+def install_all(c, quiet=False):
+    if quiet:
+        install_dependencies(c, quiet=True)
+        install_dev_dependencies(c, quiet=True)
+    else:
+        install_dependencies(c)
+        install_dev_dependencies(c)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -8,29 +8,19 @@ from ips_python.constants import INPUT_DATA_FILENAME
 
 
 @task
-def install_dependencies(c, quiet=False):
-    if quiet:
-        c.run("pip install --quiet -r requirements.txt")
-    else:
-        c.run("pip install -r requirements.txt")
+def install_dependencies(c):
+    c.run("pip install -r requirements.txt")
 
 
 @task
-def install_dev_dependencies(c, quiet=False):
-    if quiet:
-        c.run("pip install --quiet -r requirements-dev.txt")
-    else:
-        c.run("pip install -r requirements-dev.txt")
+def install_dev_dependencies(c):
+    c.run("pip install -r requirements-dev.txt")
 
 
 @task
-def install_all(c, quiet=False):
-    if quiet:
-        install_dependencies(c, quiet=True)
-        install_dev_dependencies(c, quiet=True)
-    else:
-        install_dependencies(c)
-        install_dev_dependencies(c)
+def install_all(c):
+    install_dependencies(c)
+    install_dev_dependencies(c)
 
 
 @task


### PR DESCRIPTION
when we run scripts as a module, we use the module import - e.g. `import from ips_python.constants`

but when we want to run a file as a script (`python ips_python/preprocessing.py`), we must reference the file without the reference. e.g. `import constants`

It is possible that this is not the best possible way to arrange our imports, but it seems to work for now. Any input on this is welcome