### PR TITLE
string from query df correction

### DIFF
--- a/ips_python/script.py
+++ b/ips_python/script.py
@@ -44,7 +44,7 @@ def process_query_embeddings(
     processed_query_dataframe = preprocess_query_text(query_text)
 
     query_average = average_per_doc(
-        str(processed_query_dataframe[DESCRIPTION_COLUMN_NAME]), w2v_model, 300
+        str(processed_query_dataframe[DESCRIPTION_COLUMN_NAME][0]), w2v_model, 300
     ).reshape(1, -1)
 
     df_result = get_cosine_similarity(query_average, w2v_avg, processed_iati_records)

--- a/ips_python/word2veccosine.py
+++ b/ips_python/word2veccosine.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
             full_arr = pickle.load(_file)
 
         query_average = average_per_doc(
-            str(query_df[DESCRIPTION_COLUMN_NAME]), model, 300
+            str(query_df[DESCRIPTION_COLUMN_NAME][0]), model, 300
         ).reshape(1, -1)
 
         # Using get_cosine_similarity from our cosine.py script, it removes cosine < 0 results


### PR DESCRIPTION
The input query string is pre-processed and output in a Pandas df. For the embeddings search the query is taken from the df and passed to average_per_doc function.

The way the string was being retrieved from the df as input to average_per_doc was adding extraneous characters, resulting in garbage results for 1 word searches.